### PR TITLE
Ignore generated cxx files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ migrate_working_dir/
 .pub/
 /build/
 
+# Android
+android/.cxx/
+android/app/.cxx/
+
 # Symbolication related
 app.*.symbols
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ignore rules to exclude additional Android build artifact directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->