### PR TITLE
Let user choose the http server port

### DIFF
--- a/.github/workflows/on-tag-push-create-release.yml
+++ b/.github/workflows/on-tag-push-create-release.yml
@@ -189,8 +189,6 @@ jobs:
       run: |
         TAG_NAME="${{ needs.common-vars.outputs.tag-name }}"
         cat > ${{ env.RELEASE_DIR }}/RELEASE_NOTES.md << EOF
-        # PiView Android ${TAG_NAME}
-        
         This release contains the Android APK for PiView.
         
         ## Installation

--- a/lib/route_generator.dart
+++ b/lib/route_generator.dart
@@ -23,15 +23,21 @@ class RouteGenerator {
       case '/file_browser':
         final args = settings.arguments as Map<String, dynamic>?;
         final serverIp = args?['serverIp'] as String? ?? 'localhost';
-        return _buildPageRoute(FileBrowserView(serverIp: serverIp));
+        final serverPort = args?['serverPort'] as String? ?? '8080';
+        return _buildPageRoute(FileBrowserView(
+          serverIp: serverIp,
+          serverPort: serverPort,
+        ));
       case '/media_player':
         final args = settings.arguments as Map<String, dynamic>;
         final serverAddress = args['serverAddress'] as String;
+        final serverPort = args['serverPort'] as String? ?? '8080';
         final playlist = args['playlist'] as List<MediaItem>;
         final initialIndex = args['initialIndex'] as int;
         return _buildPageRoute(
           MediaPlayerView(
             serverAddress: serverAddress,
+            serverPort: serverPort,
             playlist: playlist,
             initialIndex: initialIndex,
           ),
@@ -39,11 +45,13 @@ class RouteGenerator {
       case '/image_viewer':
         final args = settings.arguments as Map<String, dynamic>;
         final serverAddress = args['serverAddress'] as String;
+        final serverPort = args['serverPort'] as String? ?? '8080';
         final imageItem = args['imageItem'] as ImageItem;
         final allimages = args['allImages'] as List<ImageItem>;
         return _buildPageRoute(
           ImageView(
             serverAddress: serverAddress,
+            serverPort: serverPort,
             imageItem: imageItem,
             allImages: allimages,
           ),

--- a/lib/viewmodels/file_browser_viewmodel.dart
+++ b/lib/viewmodels/file_browser_viewmodel.dart
@@ -11,6 +11,7 @@ class FileBrowserViewModel extends ChangeNotifier {
   List<FileItem> _files = [];
   String _currentPath = '.';
   String _serverIp;
+  String _serverPort;
   bool _isLoading = false;
   String? _error;
   SortCriteria _sortCriteria = SortCriteria.timeEdited;
@@ -24,7 +25,7 @@ class FileBrowserViewModel extends ChangeNotifier {
   static const int itemsPerPage = 25;
   bool _hasMorePages = true;
 
-  FileBrowserViewModel(this._serverIp);
+  FileBrowserViewModel(this._serverIp, this._serverPort);
 
   List<FileItem> get files => _files;
   String get currentPath => _currentPath;
@@ -33,6 +34,7 @@ class FileBrowserViewModel extends ChangeNotifier {
   SortCriteria get sortCriteria => _sortCriteria;
   bool get isAscending => _isAscending;
   String get serverIp => _serverIp;
+  String get serverPort => _serverPort;
   int get currentPage => _currentPage;
   int get totalPages => (_totalFiles / itemsPerPage).ceil();
   bool get hasMorePages => _hasMorePages;
@@ -102,7 +104,7 @@ class FileBrowserViewModel extends ChangeNotifier {
         'limit': itemsPerPage.toString(),
       };
 
-      final url = Uri.parse('http://${_serverIp}:8080/api/v1/search')
+      final url = Uri.parse('http://$_serverIp:$_serverPort/api/v1/search')
           .replace(queryParameters: queryParams);
 
       final response = await http.get(url);
@@ -153,8 +155,9 @@ class FileBrowserViewModel extends ChangeNotifier {
         queryParams['recursive'] = 'true';
       }
 
-      final url = Uri.parse('http://${_serverIp}:8080/api/v1/$endpoint')
-          .replace(queryParameters: queryParams);
+      final url =
+          Uri.parse('http://${_serverIp}:${_serverPort}/api/v1/$endpoint')
+              .replace(queryParameters: queryParams);
 
       final response = await http.get(url);
 
@@ -246,7 +249,7 @@ class FileBrowserViewModel extends ChangeNotifier {
 
   String getThumbnailUrl(FileItem file) {
     String path = _getFilePath(file.fullName);
-    String baseUrl = 'http://$_serverIp:8080/api/v1';
+    String baseUrl = 'http://$_serverIp:${_serverPort}/api/v1';
 
     if (isVideo(file.name)) {
       return '$baseUrl/thumbnail/${Uri.encodeComponent(path)}';
@@ -352,7 +355,7 @@ class FileBrowserViewModel extends ChangeNotifier {
   Future<bool> createFolder(String folderName) async {
     try {
       final response = await http.post(
-        Uri.parse('http://$_serverIp:8080/api/v1/createfolder')
+        Uri.parse('http://$_serverIp:${_serverPort}/api/v1/createfolder')
             .replace(queryParameters: {
           'path': _getApiPath(),
           'foldername': folderName,

--- a/lib/viewmodels/login_viewmodel.dart
+++ b/lib/viewmodels/login_viewmodel.dart
@@ -8,6 +8,7 @@ class LoginViewModel extends ChangeNotifier {
   bool _isLoading = false;
   String? _error;
   static const String SERVER_IP_KEY = 'server_ip';
+  static const String SERVER_PORT_KEY = 'server_port';
 
   bool get isLoading => _isLoading;
   String? get error => _error;
@@ -17,23 +18,35 @@ class LoginViewModel extends ChangeNotifier {
     return prefs.getString(SERVER_IP_KEY);
   }
 
+  Future<String?> getLastServerPort() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(SERVER_PORT_KEY);
+  }
+
   Future<void> saveServerIp(String serverIp) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(SERVER_IP_KEY, serverIp);
   }
 
-  Future<bool> login(String server, String email, String password) async {
+  Future<void> saveServerPort(String serverIp) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(SERVER_PORT_KEY, serverIp);
+  }
+
+  Future<bool> login(
+      String server, String port, String email, String password) async {
     _isLoading = true;
     _error = null;
     notifyListeners();
 
     try {
       final response =
-          await http.get(Uri.parse('http://${server}:8080/api/v1/files'));
+          await http.get(Uri.parse('http://${server}:${port}/api/v1/files'));
       debugPrint('Status code is ${response.statusCode}');
       if (response.statusCode == 200) {
         _user = User(email: email, password: password);
         await saveServerIp(server); // Save server IP on successful login
+        await saveServerPort(port);
         _isLoading = false;
         notifyListeners();
         return true;

--- a/lib/viewmodels/media_player_viewmodel.dart
+++ b/lib/viewmodels/media_player_viewmodel.dart
@@ -3,18 +3,19 @@ import '../models/media_item.dart';
 
 class MediaPlayerViewModel extends ChangeNotifier {
   final String _serverAddress;
+  final String _serverPort;
   List<MediaItem> _playlist = [];
   int _currentIndex = 0;
   bool _isLoading = false;
   String? _error;
   MediaItem? _currentMedia;
 
-  MediaPlayerViewModel(this._serverAddress);
+  MediaPlayerViewModel(this._serverAddress, this._serverPort);
 
   bool get isLoading => _isLoading;
   String? get error => _error;
   String? get streamUrl => _currentMedia?.path != null
-      ? 'http://$_serverAddress:8080/api/v1/stream/${Uri.encodeFull(_currentMedia!.path)}'
+      ? 'http://$_serverAddress:$_serverPort/api/v1/stream/${Uri.encodeFull(_currentMedia!.path)}'
       : null;
   MediaItem? get currentMedia => _currentMedia;
   bool get hasNext => _currentIndex < _playlist.length - 1;

--- a/lib/viewmodels/upload_viewmodel.dart
+++ b/lib/viewmodels/upload_viewmodel.dart
@@ -15,7 +15,8 @@ class UploadViewModel extends ChangeNotifier {
   int get uploadedFiles => _uploadedFiles;
   double get currentFileProgress => _currentFileProgress;
 
-  Future<bool> uploadFiles(String serverIp, String currentPath, List<File> files) async {
+  Future<bool> uploadFiles(String serverIp, String serverPort,
+      String currentPath, List<File> files) async {
     _isUploading = true;
     _error = null;
     _totalFiles = files.length;
@@ -25,7 +26,8 @@ class UploadViewModel extends ChangeNotifier {
     bool allSuccess = true;
 
     for (var file in files) {
-      bool success = await _uploadSingleFile(serverIp, currentPath, file);
+      bool success =
+          await _uploadSingleFile(serverIp, serverPort, currentPath, file);
       if (!success) {
         allSuccess = false;
       }
@@ -38,11 +40,12 @@ class UploadViewModel extends ChangeNotifier {
     return allSuccess;
   }
 
-  Future<bool> _uploadSingleFile(String serverIp, String currentPath, File file) async {
+  Future<bool> _uploadSingleFile(
+      String serverIp, String serverPort, String currentPath, File file) async {
     try {
       var request = http.MultipartRequest(
         'POST',
-        Uri.parse('http://$serverIp:8080/api/v1/uploadfile'),
+        Uri.parse('http://$serverIp:$serverPort/api/v1/uploadfile'),
       );
 
       request.fields['user'] = 'default';
@@ -54,7 +57,8 @@ class UploadViewModel extends ChangeNotifier {
       if (response.statusCode == 200) {
         return true;
       } else {
-        throw Exception('Failed to upload file. Status code: ${response.statusCode}');
+        throw Exception(
+            'Failed to upload file. Status code: ${response.statusCode}');
       }
     } catch (e) {
       _error = 'Error uploading file ${file.path}: $e';

--- a/lib/views/file_browser_view.dart
+++ b/lib/views/file_browser_view.dart
@@ -15,8 +15,11 @@ import '../models/image_item.dart';
 
 class FileBrowserView extends StatefulWidget {
   final String serverIp;
+  final String serverPort;
 
-  const FileBrowserView({Key? key, required this.serverIp}) : super(key: key);
+  const FileBrowserView(
+      {Key? key, required this.serverIp, required this.serverPort})
+      : super(key: key);
 
   @override
   State<FileBrowserView> createState() => _FileBrowserViewState();
@@ -105,8 +108,9 @@ class _FileBrowserViewState extends State<FileBrowserView> {
       providers: [
         ChangeNotifierProvider(
           create: (_) {
-            final viewModel = FileBrowserViewModel(widget.serverIp)
-              ..fetchFiles();
+            final viewModel =
+                FileBrowserViewModel(widget.serverIp, widget.serverPort)
+                  ..fetchFiles();
             _viewModel = viewModel;
             return viewModel;
           },
@@ -385,6 +389,7 @@ class _FileBrowserViewState extends State<FileBrowserView> {
         '/media_player',
         arguments: {
           'serverAddress': widget.serverIp,
+          'serverPort': widget.serverPort,
           'playlist': mediaItems,
           'initialIndex': currentIndex,
         },
@@ -407,6 +412,7 @@ class _FileBrowserViewState extends State<FileBrowserView> {
               : '${viewModel.currentPath}/${file.fullName}');
       Navigator.of(context).pushNamed('/image_viewer', arguments: {
         'serverAddress': widget.serverIp,
+        'serverPort': widget.serverPort,
         'imageItem': imageItem,
         'allImages': allImages,
       });
@@ -616,6 +622,7 @@ class _FileBrowserViewState extends State<FileBrowserView> {
       List<File> files = result.paths.map((path) => File(path!)).toList();
       bool success = await uploadViewModel.uploadFiles(
         fileBrowserViewModel.serverIp,
+        fileBrowserViewModel.serverPort,
         fileBrowserViewModel.currentPath,
         files,
       );

--- a/lib/views/image_view.dart
+++ b/lib/views/image_view.dart
@@ -6,12 +6,14 @@ import '../models/image_item.dart';
 
 class ImageView extends StatefulWidget {
   final String serverAddress;
+  final String serverPort;
   final ImageItem imageItem;
   final List<ImageItem> allImages;
 
   const ImageView({
     Key? key,
     required this.serverAddress,
+    required this.serverPort,
     required this.imageItem,
     required this.allImages,
   }) : super(key: key);
@@ -70,7 +72,7 @@ class _ImageViewState extends State<ImageView> {
         .replaceAll('%23', '#')
         .replaceAll('%2C', ',');
 
-    return 'http://${widget.serverAddress}:8080/api/v1/file/$encodedPath';
+    return 'http://${widget.serverAddress}:${widget.serverPort}/api/v1/file/$encodedPath';
   }
 
   void _onTransformChanged() {

--- a/lib/views/login_view.dart
+++ b/lib/views/login_view.dart
@@ -11,6 +11,8 @@ class LoginView extends StatefulWidget {
 
 class _LoginViewState extends State<LoginView> {
   final TextEditingController _serverController = TextEditingController();
+  final TextEditingController _serverPortController =
+      TextEditingController(text: "8080");
   final TextEditingController _emailController =
       TextEditingController(text: 'test@example.com');
   final TextEditingController _passwordController =
@@ -28,13 +30,16 @@ class _LoginViewState extends State<LoginView> {
   Future<void> _loadSavedServerIp() async {
     final viewModel = Provider.of<LoginViewModel>(context, listen: false);
     final savedIp = await viewModel.getLastServerIp();
-    if (savedIp != null && mounted) {
+    final savedPort = await viewModel.getLastServerPort();
+    if (savedIp != null && mounted && savedPort != null) {
       setState(() {
         _serverController.text = savedIp;
+        _serverPortController.text = savedPort;
       });
     } else if (mounted) {
       setState(() {
         _serverController.text = '10.0.2.2';
+        _serverPortController.text = '8080';
       });
     }
   }
@@ -44,6 +49,7 @@ class _LoginViewState extends State<LoginView> {
     _emailController.dispose();
     _passwordController.dispose();
     _serverController.dispose();
+    _serverPortController.dispose();
     super.dispose();
   }
 
@@ -129,6 +135,11 @@ class _LoginViewState extends State<LoginView> {
                       ),
                       const SizedBox(height: 16),
                       PiViewTextField(
+                          controller: _serverPortController,
+                          label: "Port",
+                          icon: Icons.settings_ethernet_rounded),
+                      const SizedBox(height: 16),
+                      PiViewTextField(
                         controller: _emailController,
                         label: 'Email',
                         icon: Icons.email_outlined,
@@ -154,6 +165,7 @@ class _LoginViewState extends State<LoginView> {
                             : () async {
                                 bool success = await model.login(
                                   _serverController.text,
+                                  _serverPortController.text,
                                   _emailController.text,
                                   _passwordController.text,
                                 );
@@ -162,7 +174,8 @@ class _LoginViewState extends State<LoginView> {
                                     context,
                                     '/file_browser',
                                     arguments: {
-                                      'serverIp': _serverController.text
+                                      'serverIp': _serverController.text,
+                                      'serverPort': _serverPortController.text,
                                     },
                                   );
                                 } else if (mounted) {

--- a/lib/views/media_player_view.dart
+++ b/lib/views/media_player_view.dart
@@ -11,12 +11,14 @@ import '../models/media_item.dart';
 
 class MediaPlayerView extends StatelessWidget {
   final String serverAddress;
+  final String serverPort;
   final List<MediaItem> playlist;
   final int initialIndex;
 
   const MediaPlayerView({
     Key? key,
     required this.serverAddress,
+    required this.serverPort,
     required this.playlist,
     required this.initialIndex,
   }) : super(key: key);
@@ -24,7 +26,7 @@ class MediaPlayerView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => MediaPlayerViewModel(serverAddress)
+      create: (_) => MediaPlayerViewModel(serverAddress, serverPort)
         ..setPlaylist(playlist, initialIndex),
       child: Scaffold(
         appBar: AppBar(


### PR DESCRIPTION
- update release note with github actions
- let the user choose the server port rather than hard-coded 8080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom server port throughout the app, including login, file browsing, media playback, image viewing, and file uploads.
  - Users can now enter and save a server port in the login screen, with the default set to "8080".

- **Bug Fixes**
  - URLs for server communication now use the specified port instead of a hardcoded value.

- **Chores**
  - Updated release notes formatting to remove the automatic top-level heading with the release tag name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->